### PR TITLE
Remove file checks in upload function

### DIFF
--- a/easyverein/core/client.py
+++ b/easyverein/core/client.py
@@ -206,11 +206,6 @@ class EasyvereinClient:
 
         Only tested with invoices so far
         """
-        # Check that path is a file and it exists
-        if not file.exists() or not file.is_file():
-            self.logger.error("File does not exist or is not a file.")
-            raise FileNotFoundError("File does not exist")
-
         files = {field_name: open(file, "rb")}
         headers = {"Content-Disposition": f'name="file"; filename="{file.name}"'}
 


### PR DESCRIPTION
This changes allows usage of `BytesIO` to be used when uploading.

My use-case is downloading, modifying and reuploading, without saving the data to a file:

```python
data, headers = ev_client.invoice.get_attachment(invoice)
# modify data
ev_client.invoice.upload_attachment(invoice, io.BytesIO(data))
```