### PR TITLE
Retry on EasyvereinAPITooManyRetriesException

### DIFF
--- a/easyverein/api.py
+++ b/easyverein/api.py
@@ -32,7 +32,9 @@ class EasyvereinAPI:
         else:
             self.logger = logging.getLogger("easyverein")
 
-        self.c = EasyvereinClient(api_key, api_version, base_url, self.logger, self, auto_retry)
+        self.c = EasyvereinClient(
+            api_key, api_version, base_url, self.logger, self, auto_retry
+        )
 
         # Add methods
 

--- a/easyverein/api.py
+++ b/easyverein/api.py
@@ -19,6 +19,7 @@ class EasyvereinAPI:
         api_version="v1.7",
         base_url: str = "https://hexa.easyverein.com/api/",
         logger: logging.Logger = None,
+        auto_retry=False,
     ):
         """
         Constructor setting API key and logger. Test
@@ -31,7 +32,7 @@ class EasyvereinAPI:
         else:
             self.logger = logging.getLogger("easyverein")
 
-        self.c = EasyvereinClient(api_key, api_version, base_url, self.logger, self)
+        self.c = EasyvereinClient(api_key, api_version, base_url, self.logger, self, auto_retry)
 
         # Add methods
 

--- a/easyverein/core/client.py
+++ b/easyverein/core/client.py
@@ -125,8 +125,10 @@ class EasyvereinClient:
                 self.logger.warning("Retrying after %d seconds sleep.", retry_after)
                 sleep(retry_after)
                 if files:
-                    for k,v in files:
-                        v.seek(0)  # reset file seek, as it has been moved by the previous call
+                    for k, v in files:
+                        v.seek(
+                            0
+                        )  # reset file seek, as it has been moved by the previous call
                 return self._do_request(method, url, binary, data, headers, files)
             else:
                 raise EasyvereinAPITooManyRetriesException(

--- a/easyverein/core/client.py
+++ b/easyverein/core/client.py
@@ -125,10 +125,11 @@ class EasyvereinClient:
                 self.logger.warning("Retrying after %d seconds sleep.", retry_after)
                 sleep(retry_after)
                 if files:
-                    for k, v in files:
+                    for v in files.values():
                         v.seek(
                             0
                         )  # reset file seek, as it has been moved by the previous call
+
                 return self._do_request(method, url, binary, data, headers, files)
             else:
                 raise EasyvereinAPITooManyRetriesException(

--- a/easyverein/core/client.py
+++ b/easyverein/core/client.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
 from time import sleep
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import requests
 from pydantic import BaseModel
@@ -123,9 +123,11 @@ class EasyvereinClient:
                 self.logger.warning("Sleeping %d seconds", retry_after)
                 sleep(retry_after)
                 if files:
-                    for k,v in files:
+                    for k, v in files:
                         v.seek(0)
-                return self._do_request(method, url, binary, data, headers, files, retry=False)
+                return self._do_request(
+                    method, url, binary, data, headers, files, retry=False
+                )
             else:
                 raise EasyvereinAPITooManyRetriesException(
                     f"Too many requests, please wait {retry_after} seconds and try again.",


### PR DESCRIPTION
I extended `_do_request` to automatically retry if `EasyvereinAPITooManyRetriesException` would have been thrown.

This is only a rough implementation –probably not suited for merge–, but I would like your feedback on the idea.