### PR TITLE
Workaround: urlencode invoice.path

### DIFF
--- a/easyverein/modules/invoice.py
+++ b/easyverein/modules/invoice.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
+import re
 from typing import List
+import urllib
 
 from requests.structures import CaseInsensitiveDict
 
@@ -169,4 +171,10 @@ class InvoiceMixin(
                 "Unable to obtain a valid path for given invoice."
             )
 
-        return self.c.fetch_file(path)
+        # Fix for unencoded characters - should probably be fixed in easyverein API
+        m = re.fullmatch(r'^(.*\&path=)(.*)(&storedInS3=True)$', path.unicode_string())
+        url_components = list(m.groups())
+        if '%' not in url_components[1]:
+            url_components[1] = urllib.parse.quote(url_components[1])
+
+        return self.c.fetch_file(''.join(url_components))

--- a/easyverein/modules/invoice.py
+++ b/easyverein/modules/invoice.py
@@ -1,8 +1,8 @@
 import logging
-from pathlib import Path
 import re
-from typing import List
 import urllib
+from pathlib import Path
+from typing import List
 
 from requests.structures import CaseInsensitiveDict
 
@@ -172,9 +172,9 @@ class InvoiceMixin(
             )
 
         # Fix for unencoded characters - should probably be fixed in easyverein API
-        m = re.fullmatch(r'^(.*\&path=)(.*)(&storedInS3=True)$', path.unicode_string())
+        m = re.fullmatch(r"^(.*\&path=)(.*)(&storedInS3=True)$", path.unicode_string())
         url_components = list(m.groups())
-        if '%' not in url_components[1]:
+        if "%" not in url_components[1]:
             url_components[1] = urllib.parse.quote(url_components[1])
 
-        return self.c.fetch_file(''.join(url_components))
+        return self.c.fetch_file("".join(url_components))


### PR DESCRIPTION
It turns out that easyverein returns invoice.path both with and without correct urlencoded file parameter.

e.g.

```python
>>> for i in invoices:
...     if i.path:
...         print(i.path.unicode_string())
[...]
# correct urlencoding of file parameter:
https://hexa.easyverein.com/app/file?category=invoice&path=2022/05/Rechnungen/1708198219105267-95.1_95.2_Hoge_Tagess%C3%A4tze_Fahrtkosten.pdf&storedInS3=True
# missing urlencoding of file parameter (# and + must be encoded with %xx):
https://hexa.easyverein.com/app/file?category=invoice&path=2023/12/Rechnungen/1708268215253392-EV_#28426.pdf&storedInS3=True
https://hexa.easyverein.com/app/file?category=invoice&path=2023/11/Rechnungen/1708268206711717-033_ZAM_7._AZ-L_+_R_231129.pdf&storedInS3=True
```

This problem leads to attachments of invoices not being downloadable.

This PR is a workaround, which may not always be correct, but has fixed this issue in all our cases (>1500 invoices).