### PR TITLE
add support for nested MemberGroup models in MemberMemberGroup

### DIFF
--- a/easyverein/models/member_member_group.py
+++ b/easyverein/models/member_member_group.py
@@ -23,7 +23,7 @@ class MemberMemberGroupBase(EasyVereinBase):
     """
 
     userObject: EasyVereinReference | Member | None = None
-    memberGroup: EasyVereinReference | None = None
+    memberGroup: EasyVereinReference | MemberGroup | None = None
     paymentAmount: float | None = None
     paymentActive: bool = False
     start: Any | None = None  # Field not documented
@@ -70,3 +70,4 @@ class MemberMemberGroupFilter(BaseModel):
 
 
 from .member import Member  # noqa: E402
+from .member_group import MemberGroup  # noqa: E402


### PR DESCRIPTION
`ev_client.member.get(query='{id,memberGroups{memberGroup{id}}}')` would previously throw pydantic validation errors, due to the nested `memberGroup` not being a reference URL.

This patch allows both nesting and references, as was already supported with the `memberGroups` attribute.