### PR TITLE
add exclude_none argument to CRUD update function to be able to unset…

### DIFF
--- a/easyverein/core/client.py
+++ b/easyverein/core/client.py
@@ -191,7 +191,7 @@ class EasyvereinClient:
         """
         return self._handle_response(self._do_request("delete", url), expected_status_code=status_code)
 
-    def update(self, url, data: BaseModel, status_code: int = 200) -> ResponseSchema:
+    def update(self, url, data: BaseModel, status_code: int = 200, exclude_none: bool = True) -> ResponseSchema:
         """
         Method to update an object in the API
         """
@@ -199,7 +199,7 @@ class EasyvereinClient:
             self._do_request(
                 "patch",
                 url,
-                data=data.model_dump(exclude_none=True, exclude_unset=True, by_alias=True),
+                data=data.model_dump(exclude_none=exclude_none, exclude_unset=True, by_alias=True),
             ),
             expected_status_code=status_code,
         )

--- a/easyverein/modules/mixins/crud.py
+++ b/easyverein/modules/mixins/crud.py
@@ -139,7 +139,7 @@ class CRUDMixin(Generic[ModelType, CreateModelType, UpdateModelType, FilterType]
         Args:
             target: Model instance to update or id of the model to update
             data: Pydantic Model holding data to update the model
-            exclude_none: exclude fiels with None, set to False to explicitly unset fields
+            exclude_none: exclude fields with None, set to False to explicitly unset fields
         """
 
         obj_id = get_id(target)

--- a/easyverein/modules/mixins/crud.py
+++ b/easyverein/modules/mixins/crud.py
@@ -129,7 +129,9 @@ class CRUDMixin(Generic[ModelType, CreateModelType, UpdateModelType, FilterType]
         assert isinstance(parsed_object, self.return_type)
         return parsed_object
 
-    def update(self: EVClientProtocol[ModelType], target: ModelType | int, data: UpdateModelType, exclude_none: bool = True) -> ModelType:
+    def update(
+        self: EVClientProtocol[ModelType], target: ModelType | int, data: UpdateModelType, exclude_none: bool = True
+    ) -> ModelType:
         """
         Updates (PATCHes) a certain object and returns the updated object. Accepts either an object
         or its id as first argument.

--- a/easyverein/modules/mixins/crud.py
+++ b/easyverein/modules/mixins/crud.py
@@ -129,7 +129,7 @@ class CRUDMixin(Generic[ModelType, CreateModelType, UpdateModelType, FilterType]
         assert isinstance(parsed_object, self.return_type)
         return parsed_object
 
-    def update(self: EVClientProtocol[ModelType], target: ModelType | int, data: UpdateModelType) -> ModelType:
+    def update(self: EVClientProtocol[ModelType], target: ModelType | int, data: UpdateModelType, exclude_none: bool = True) -> ModelType:
         """
         Updates (PATCHes) a certain object and returns the updated object. Accepts either an object
         or its id as first argument.
@@ -137,6 +137,7 @@ class CRUDMixin(Generic[ModelType, CreateModelType, UpdateModelType, FilterType]
         Args:
             target: Model instance to update or id of the model to update
             data: Pydantic Model holding data to update the model
+            exclude_none: exclude fiels with None, set to False to explicitly unset fields
         """
 
         obj_id = get_id(target)
@@ -144,7 +145,7 @@ class CRUDMixin(Generic[ModelType, CreateModelType, UpdateModelType, FilterType]
         self.logger.info(f"Updating object of type {self.endpoint_name} with id {obj_id}")
 
         url = self.c.get_url(f"/{self.endpoint_name}/{obj_id}")
-        response = self.c.update(url, data)
+        response = self.c.update(url, data, exclude_none=exclude_none)
         assert isinstance(response.result, dict)
         parsed_object = parse_models(response.result, self.return_type)
         assert isinstance(parsed_object, self.return_type)


### PR DESCRIPTION
… attributes on easyverein endpoints

I wanted to unset (set to None/null) the `end` attribute in MemberMemberGroup, which is currently not possible via the `CRUDMixin`. This patch passes allong the `exclude_none` parameter from the `update` function to the `model_dump`.