### PR TITLE
Member.paymentIntervallMonths does not support null/None, but also -1

### DIFF
--- a/easyverein/models/member.py
+++ b/easyverein/models/member.py
@@ -60,7 +60,7 @@ class MemberBase(EasyVereinBase):
     Alias for `_paymentStartDate` field. See [Pydantic Models](../usage.md#pydantic-models) for details.
     """
     paymentAmount: float | None = None
-    paymentIntervallMonths: PositiveInt | None = None
+    paymentIntervallMonths: PositiveInt | Literal[-1] = 1
     useBalanceForMembershipFee: bool | None = None
     bulletinBoardNewPostNotification: bool | None = None
     integrationDosbGender: Literal["m", "w", "d"] | None = None


### PR DESCRIPTION
when disabling "Individueller Mitgliedschaftsbeitrag" `paymentIntervallMonths` is set to `-1`, which apparently means "Einmalig, bei der nächsten automatischen erzeugten Rechnung". Setting a None/null value, results in "Dieses Feld darf nicht null sein."