### PR TITLE
fix date__isnull types in MemberFilter

### DIFF
--- a/easyverein/models/member.py
+++ b/easyverein/models/member.py
@@ -144,16 +144,16 @@ class MemberFilter(BaseModel):
     joinDate: DateTime | None = None
     joinDate__gte: DateTime | None = None
     joinDate__lte: DateTime | None = None
-    joinDate__isnull: DateTime | None = None
+    joinDate__isnull: bool | None = None
     resignationDate: DateTime | None = None
     resignationDate__gte: DateTime | None = None
     resignationDate__lte: DateTime | None = None
-    resignationDate__isnull: DateTime | None = None
+    resignationDate__isnull: bool | None = None
     isApplication: bool = Field(default=None, serialization_alias="_isApplication")
     applicationDate: Date = Field(default=None, serialization_alias="_applicationDate")
     applicationDate__gte: Date = Field(default=None, serialization_alias="_applicationDate__gte")
     applicationDate__lte: Date = Field(default=None, serialization_alias="_applicationDate__lte")
-    applicationDate__isnull: Date = Field(default=None, serialization_alias="_applicationDate__isnull")
+    applicationDate__isnull: bool = Field(default=None, serialization_alias="_applicationDate__isnull")
     applicationWasAcceptedAt: Date = Field(default=None, serialization_alias="_applicationWasAcceptedAt")
     applicationWasAcceptedAt__gte: Date = Field(default=None, serialization_alias="_applicationWasAcceptedAt__gte")
     applicationWasAcceptedAt__lte: Date = Field(default=None, serialization_alias="_applicationWasAcceptedAt__lte")


### PR DESCRIPTION
They should be bools, but had the date type of its object, probably due to a copy&paste error