### PR TITLE
Add field closingDescription to InvoiceBase

### DIFF
--- a/easyverein/models/invoice.py
+++ b/easyverein/models/invoice.py
@@ -37,6 +37,7 @@ class InvoiceBase(EasyVereinBase):
     invNumber: str | None = None
     receiver: str | None = None
     description: str | None = None
+    closingDescription: str | None = None
     totalPrice: float | None = None
     tax: float | None = None
     taxRate: float | None = None


### PR DESCRIPTION
This PR adds the field `closingDescription` to the `InvoiceBase` class. The field is present in the v2 API and allows to add text under the itemized part of the invoice.